### PR TITLE
Auto discovery of readers, total of readers and image file name at completion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,19 @@ Then proceed to modify those files to match the system paths for the items in th
 * It will then open up chromium-browser and navigate to the hostname and port.
 	* So define the url that the browser will use to connect to the main page.
 
+* Alternatively, you can decide to run OSID headless on a networked Raspberry. You can safely uncomment the chromuim line in run_app.sh. Don't forget to set local Raspbery Pi IP on server.ini
+
 #### osid.desktop
 * Just make sure the path for the run_app.sh script is defined properly.
+* if you use OSID on headless Raspberry, this file is useless.
+
+### Usage
+
+#### Accepted image file
+OSID will accept any image file ending with .img name. Other will silently be ignored.
+
+#### Auto discovery of available readers
+When refreshing web page (or accessing it), OSID will scan available readers, and after some seconds, will show them on the menu. A sum of all readers is also shown.
 
 ## Built With
 

--- a/www/index.html
+++ b/www/index.html
@@ -121,7 +121,7 @@
                                 if (array.length == 0) {
                                     var device_html_buttons = 'No Devices Found'
                                 } else {
-                                    device_html_buttons += "<input type=\"checkbox\" onClick=\"select_all(this)\" /> Select All Devices<br/>"
+                                    device_html_buttons += "<input type=\"checkbox\" onClick=\"select_all(this)\" /> Select All Devices (" + array.length + ") <br/>"
                                     for (var i = 0; i < array.length; i++) {
                                         device_html_buttons += '<input type="checkbox" id="devices" name="devices" value="' + array[i].name + '">' + array[i].name + ' (' + array[i].size + ')' + '<br>';
                                     }

--- a/www/monitor.html
+++ b/www/monitor.html
@@ -47,7 +47,7 @@
                             elem.innerHTML = width * 1 + '%';
 
                             if (width == 100) {
-                                completed_html = "Duplication Complete<br>"
+                                completed_html = "Duplication Complete: " + array.img_name + "<br>"
                                 completed_html += "<a href=\"http://replacewithhostnamehere\">Return to Start</a>"
                                 document.getElementById("StatusMessage").innerHTML = completed_html
                             } else {


### PR DESCRIPTION
Hi,

This PR improve some features of this nice OSID tool:

- Auto discovery on any computer (using partprobe) of available readers.
- Total of readers discovered (useful for mass copy, you know if all readers are available, no need to count them)
- When copy is done, source image filename is shown to avoid confusion/error.


![total](https://user-images.githubusercontent.com/4921816/37846998-ac787a6e-2ecf-11e8-8d79-9696adcc8d2b.png)
![filename](https://user-images.githubusercontent.com/4921816/37846999-acb40552-2ecf-11e8-961c-1e6fbc2b4f47.png)

